### PR TITLE
Kodi Mock Harness and Workspace Stability Fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +691,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.3.1",
+ "indexmap 2.9.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +773,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,9 +817,9 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
- "http-body",
+ "http-body 0.4.6",
  "httparse",
  "httpdate",
  "itoa",
@@ -784,16 +832,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2 0.4.13",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
 dependencies = [
  "bytes",
- "hyper",
+ "hyper 0.14.32",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "bytes",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -1065,7 +1149,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.13.1",
  "jsonrpc",
- "mockito",
+ "mockito 0.31.1",
  "rand 0.9.1",
  "rand_chacha 0.9.0",
  "reqwest",
@@ -1258,6 +1342,31 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "similar",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand 0.9.1",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -1718,10 +1827,10 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
+ "h2 0.3.26",
  "http 0.2.12",
- "http-body",
- "hyper",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -1825,7 +1934,7 @@ dependencies = [
  "either",
  "futures",
  "http 0.2.12",
- "hyper",
+ "hyper 0.14.32",
  "indexmap 2.9.0",
  "log",
  "memchr",
@@ -2439,6 +2548,7 @@ version = "0.1.0"
 dependencies = [
  "env_logger",
  "koditool",
+ "mockito 1.7.2",
  "rand 0.9.1",
  "reqwest",
  "rocket",

--- a/jukeingest/src/main.rs
+++ b/jukeingest/src/main.rs
@@ -112,7 +112,7 @@ fn process_directory(root_path: &str, threshold_time: SystemTime, playlist: &mut
         .filter_map(|e| e.ok())
         .filter(|e| {
             e.metadata().map(|m| {
-                m.is_file() && m.modified().map_or(false, |mod_time| mod_time > threshold_time)
+                m.is_file() && m.modified().is_ok_and(|mod_time| mod_time > threshold_time)
             }).unwrap_or(false) && !e.path().starts_with(&playlists_path)
         })
     {
@@ -149,7 +149,7 @@ fn save_last_run_timestamp() -> io::Result<()> {
 
         let timestamp = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?
+            .map_err(io::Error::other)?
             .as_secs();
 
         let mut file = OpenOptions::new()
@@ -161,7 +161,7 @@ fn save_last_run_timestamp() -> io::Result<()> {
         write!(file, "{}", timestamp)?;
         return Ok(());
     }
-    Err(io::Error::new(io::ErrorKind::Other, "Failed to determine home directory"))
+    Err(io::Error::other("Failed to determine home directory"))
 }
 
 fn read_last_run_timestamp() -> io::Result<Option<SystemTime>> {

--- a/koditool/src/tvmode.rs
+++ b/koditool/src/tvmode.rs
@@ -10,8 +10,6 @@ use std::time::Duration;
 use tokio::time::sleep;
 
 use serde::Deserialize;
-use serde_yaml;
-
 #[derive(Debug, Deserialize)]
 struct ShowMappings {
     #[serde(flatten)]
@@ -24,7 +22,7 @@ fn load_show_mappings() -> Result<ShowMappings, Box<dyn std::error::Error>> {
     Ok(show_mappings)
 }
 
-fn select_random_show_name<'a>(shows: &'a [String]) -> Option<&'a String> {
+fn select_random_show_name(shows: &[String]) -> Option<&String> {
     shows.choose(&mut rand::rng())
 }
 
@@ -44,7 +42,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let user_shows = show_mappings
         .shows
         .get(user)
-        .ok_or_else(|| "User not found")?;
+        .ok_or("User not found")?;
 
     if user_shows.is_empty() {
         eprintln!("No shows available for this user.");
@@ -63,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("\n[!] no show playing, calling other Rust binary...\n");
 
             let selected_episode = rpc_client
-                .select_random_episode_by_title(&selected_show_name)
+                .select_random_episode_by_title(selected_show_name)
                 .await?;
             rpc_client.rpc_play(&selected_episode).await?;
 

--- a/koditool/tests/kodi_helper_test.rs
+++ b/koditool/tests/kodi_helper_test.rs
@@ -208,7 +208,7 @@ mod tests {
 
         let client = test_client();
         let result = client.is_active().await.unwrap();
-        assert_eq!(result, true);
+        assert!(result);
     }
 
     #[tokio::test]
@@ -221,7 +221,7 @@ mod tests {
 
         let client = test_client();
         let result = client.is_active().await.unwrap();
-        assert_eq!(result, false);
+        assert!(!result);
     }
 
     #[tokio::test]

--- a/tv_mode_web/src/app_state.rs
+++ b/tv_mode_web/src/app_state.rs
@@ -61,6 +61,12 @@ pub struct SleepTimer {
 
 impl SleepTimer {
     pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Default for SleepTimer {
+    fn default() -> Self {
         Self {
             enabled: false,
             duration_hours: 2, // Default 2 hours
@@ -68,7 +74,9 @@ impl SleepTimer {
             remaining_seconds: None,
         }
     }
+}
 
+impl SleepTimer {
     pub fn start(&mut self, duration_hours: u32) {
         self.enabled = true;
         self.duration_hours = duration_hours;
@@ -92,7 +100,7 @@ impl SleepTimer {
         }
 
         self.update_remaining_time_const();
-        self.remaining_seconds.map_or(true, |remaining| remaining == 0)
+        self.remaining_seconds.is_none_or(|remaining| remaining == 0)
     }
 
     pub fn update_remaining_time(&mut self) {
@@ -132,15 +140,11 @@ impl SleepTimer {
         let elapsed_seconds = current_timestamp.saturating_sub(start_timestamp);
         let total_seconds = (self.duration_hours as u64) * 3600;
 
-        if elapsed_seconds >= total_seconds {
-            0
-        } else {
-            total_seconds - elapsed_seconds
-        }
+        total_seconds.saturating_sub(elapsed_seconds)
     }
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct TVModeStatus {
     pub active: bool,
     pub user: Option<String>,
@@ -149,13 +153,11 @@ pub struct TVModeStatus {
 
 impl TVModeStatus {
     pub fn new() -> Self {
-        Self {
-            active: false,
-            user: None,
-            sleep_timer: SleepTimer::new(),
-        }
+        Self::default()
     }
+}
 
+impl TVModeStatus {
     // Helper method to update sleep timer remaining time before serialization
     pub fn with_updated_timer(&mut self) -> &Self {
         self.sleep_timer.update_remaining_time();
@@ -185,10 +187,7 @@ pub fn initialize() -> Result<AppState, std::io::Error> {
         Ok(config) => config,
         Err(e) => {
             eprintln!("Failed to load config from {:?}: {}", config_path, e);
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                e.to_string(),
-            ));
+            return Err(std::io::Error::other(e.to_string()));
         }
     };
 
@@ -197,10 +196,7 @@ pub fn initialize() -> Result<AppState, std::io::Error> {
         Ok(client) => client,
         Err(e) => {
             eprintln!("Failed to create RPC client: {}", e);
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                e.to_string(),
-            ));
+            return Err(std::io::Error::other(e.to_string()));
         }
     };
 
@@ -212,7 +208,7 @@ pub fn initialize() -> Result<AppState, std::io::Error> {
                 "Failed to load show mappings from {:?}: {}",
                 mappings_path, e
             );
-            return Err(std::io::Error::new(std::io::ErrorKind::Other, e));
+            return Err(std::io::Error::other(e));
         }
     };
 

--- a/tv_mode_web/src/routes/index.rs
+++ b/tv_mode_web/src/routes/index.rs
@@ -7,7 +7,7 @@ use crate::app_state::AppState;
 #[get("/")]
 pub async fn index(_app_state: &State<AppState>) -> Template {
     let context = "";
-    Template::render("index", &context)
+    Template::render("index", context)
 }
 
 // Return routes defined in this module

--- a/tv_mode_web/src/scheduler/mod.rs
+++ b/tv_mode_web/src/scheduler/mod.rs
@@ -72,7 +72,7 @@ async fn scheduler_mainbody(app_state: AppState) {
         iteration_count += 1;
 
         // Log iteration count periodically instead of every time
-        if iteration_count % 12 == 0 {
+        if iteration_count.is_multiple_of(12) {
             // Every minute with 5s intervals
             debug!("Scheduler iteration #{}", iteration_count);
         }
@@ -100,7 +100,7 @@ async fn scheduler_mainbody(app_state: AppState) {
 
                 // Only log errors occasionally to prevent spam
                 if scheduler_state.consecutive_errors <= 3
-                    || scheduler_state.consecutive_errors % 10 == 0
+                    || scheduler_state.consecutive_errors.is_multiple_of(10)
                 {
                     error!(
                         "Scheduler error #{}: {} (will retry in {}s)",
@@ -205,7 +205,7 @@ async fn process_scheduler_iteration(app_state: &AppState) -> Result<bool, Strin
     Ok(true)
 }
 
-fn select_random_show_name<'a>(shows: &'a [String]) -> Option<&'a String> {
+fn select_random_show_name(shows: &[String]) -> Option<&String> {
     if shows.is_empty() {
         return None;
     }

--- a/tv_mode_web/tests/harness/mod.rs
+++ b/tv_mode_web/tests/harness/mod.rs
@@ -1,0 +1,163 @@
+use mockito::{Server, Mock};
+use serde_json::json;
+use std::time::Duration;
+
+use mockito::ServerGuard;
+
+pub struct KodiMock {
+    server: ServerGuard,
+}
+
+#[allow(dead_code)]
+impl KodiMock {
+    pub async fn new() -> Self {
+        Self {
+            server: Server::new_async().await,
+        }
+    }
+
+    pub fn url(&self) -> String {
+        self.server.url()
+    }
+
+    pub async fn mock_get_tv_shows(&mut self) -> Mock {
+        self.server.mock("POST", "/jsonrpc")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "VideoLibrary.GetTVShows"})))
+            .with_header("content-type", "application/json")
+            .with_body(json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "result": {
+                    "tvshows": [
+                        { "tvshowid": 1, "title": "The Office" },
+                        { "tvshowid": 2, "title": "Breaking Bad" }
+                    ],
+                    "limits": { "end": 2, "start": 0, "total": 2 }
+                }
+            }).to_string())
+            .create_async()
+            .await
+    }
+
+    pub async fn mock_get_episodes(&mut self) -> Mock {
+        self.server.mock("POST", "/jsonrpc")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "VideoLibrary.GetEpisodes"})))
+            .with_header("content-type", "application/json")
+            .with_body(json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "result": {
+                    "episodes": [
+                        { "episodeid": 101, "title": "Pilot", "season": 1, "episode": 1 },
+                        { "episodeid": 102, "title": "Diversity Day", "season": 1, "episode": 2 }
+                    ],
+                    "limits": { "end": 2, "start": 0, "total": 12 }
+                }
+            }).to_string())
+            .create_async()
+            .await
+    }
+
+    pub async fn mock_get_episode_details(&mut self) -> Mock {
+        self.server.mock("POST", "/jsonrpc")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "VideoLibrary.GetEpisodeDetails"})))
+            .with_header("content-type", "application/json")
+            .with_body(json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "result": {
+                    "episodedetails": {
+                        "file": "/media/tv/The Office/S01E01.mkv",
+                        "label": "Pilot"
+                    }
+                }
+            }).to_string())
+            .create_async()
+            .await
+    }
+
+    pub async fn mock_get_active_players_none(&mut self) -> Mock {
+        self.server.mock("POST", "/jsonrpc")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "Player.GetActivePlayers"})))
+            .with_header("content-type", "application/json")
+            .with_body(json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "result": []
+            }).to_string())
+            .create_async()
+            .await
+    }
+
+    pub async fn mock_get_active_players_active(&mut self) -> Mock {
+        self.server.mock("POST", "/jsonrpc")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "Player.GetActivePlayers"})))
+            .with_header("content-type", "application/json")
+            .with_body(json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "result": [
+                    { "playerid": 1, "type": "video" }
+                ]
+            }).to_string())
+            .create_async()
+            .await
+    }
+
+    pub async fn mock_player_open(&mut self) -> Mock {
+        self.server.mock("POST", "/jsonrpc")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "Player.Open"})))
+            .with_header("content-type", "application/json")
+            .with_body(json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "result": "OK"
+            }).to_string())
+            .create_async()
+            .await
+    }
+
+    pub async fn mock_player_stop(&mut self) -> Mock {
+        self.server.mock("POST", "/jsonrpc")
+            .match_body(mockito::Matcher::PartialJson(json!({"method": "Player.Stop"})))
+            .with_header("content-type", "application/json")
+            .with_body(json!({
+                "id": 1,
+                "jsonrpc": "2.0",
+                "result": "OK"
+            }).to_string())
+            .create_async()
+            .await
+    }
+
+    pub async fn mock_timeout(&mut self, delay: Duration) -> Mock {
+        self.server.mock("POST", "/jsonrpc")
+            .with_chunked_body(move |w| {
+                std::thread::sleep(delay);
+                let _ = w.write_all(json!({
+                    "id": 1,
+                    "jsonrpc": "2.0",
+                    "result": "OK"
+                }).to_string().as_bytes());
+                Ok(())
+            })
+            .with_header("content-type", "application/json")
+            .create_async()
+            .await
+    }
+
+    pub async fn mock_malformed(&mut self) -> Mock {
+        self.server.mock("POST", "/jsonrpc")
+            .with_header("content-type", "application/json")
+            .with_body("invalid json { [")
+            .create_async()
+            .await
+    }
+
+    pub async fn mock_http_error(&mut self, status: usize) -> Mock {
+        self.server.mock("POST", "/jsonrpc")
+            .with_status(status)
+            .create_async()
+            .await
+    }
+}

--- a/tv_mode_web/tests/web_integrity.rs
+++ b/tv_mode_web/tests/web_integrity.rs
@@ -1,12 +1,16 @@
+mod harness;
+
+use harness::KodiMock;
 use rocket::local::asynchronous::Client;
 use rocket::http::Status;
 use std::fs;
 use std::env;
+use std::time::Duration;
 use tempfile::tempdir;
 
 #[rocket::async_test]
 async fn test_health_check() {
-    let client = create_test_client().await;
+    let client = create_test_client(None).await;
     let response = client.get("/api/health").dispatch().await;
     assert_eq!(response.status(), Status::Ok);
     let body = response.into_string().await.unwrap();
@@ -16,7 +20,7 @@ async fn test_health_check() {
 
 #[rocket::async_test]
 async fn test_index_page() {
-    let client = create_test_client().await;
+    let client = create_test_client(None).await;
     let response = client.get("/").dispatch().await;
     assert_eq!(response.status(), Status::Ok);
     let body = response.into_string().await.unwrap();
@@ -27,7 +31,7 @@ async fn test_index_page() {
 
 #[rocket::async_test]
 async fn test_jukectl_page() {
-    let client = create_test_client().await;
+    let client = create_test_client(None).await;
     let response = client.get("/jukectl").dispatch().await;
     assert_eq!(response.status(), Status::Ok);
     let body = response.into_string().await.unwrap();
@@ -35,13 +39,58 @@ async fn test_jukectl_page() {
     assert!(body.contains("Jukebox"));
 }
 
-async fn create_test_client() -> Client {
+#[rocket::async_test]
+async fn test_resilience_kodi_unreachable() {
+    // Use an unreachable port
+    let client = create_test_client(Some("http://127.0.0.1:1")).await;
+    let response = client.get("/api/status").dispatch().await;
+
+    assert_eq!(response.status(), Status::Ok);
+    let body: serde_json::Value = response.into_json().await.unwrap();
+    assert_eq!(body["status"], "error");
+    // The error message might vary based on the OS/environment,
+    // but it should contain something about the connection failure or RPC error.
+    assert!(body["error_details"].as_str().is_some());
+}
+
+#[rocket::async_test]
+async fn test_resilience_kodi_timeout() {
+    let mut mock = KodiMock::new().await;
+    // RPC_TIMEOUT is 5s, so we delay for 6s
+    let _m = mock.mock_timeout(Duration::from_secs(6)).await;
+
+    let client = create_test_client(Some(&mock.url())).await;
+    let response = client.get("/api/status").dispatch().await;
+
+    assert_eq!(response.status(), Status::Ok);
+    let body: serde_json::Value = response.into_json().await.unwrap();
+    assert_eq!(body["status"], "error");
+    assert!(body["error_details"].as_str().unwrap().contains("timed out"));
+}
+
+#[rocket::async_test]
+async fn test_resilience_kodi_malformed_json() {
+    let mut mock = KodiMock::new().await;
+    let _m = mock.mock_malformed().await;
+
+    let client = create_test_client(Some(&mock.url())).await;
+    let response = client.get("/api/status").dispatch().await;
+
+    assert_eq!(response.status(), Status::Ok);
+    let body: serde_json::Value = response.into_json().await.unwrap();
+    assert_eq!(body["status"], "error");
+    // Should be an error message about parsing
+    assert!(body["error_details"].as_str().is_some());
+}
+
+async fn create_test_client(kodi_url: Option<&str>) -> Client {
     // Set up a temporary config directory
     let tmp_dir = tempdir().expect("Failed to create temp dir");
     let config_dir = tmp_dir.path();
     
     // Create dummy config files
-    let config_yml = "url: http://localhost:8080\nusername: user\npassword: pass\n";
+    let url = kodi_url.unwrap_or("http://localhost:8080");
+    let config_yml = format!("url: {}\nusername: user\npassword: pass\n", url);
     let show_mappings_yml = "user1:\n  - Show 1\n  - Show 2\n";
     let jukectl_channels_yml = "channels:\n  - name: Channel 1\n    any: [\"tag1\"]\n";
     


### PR DESCRIPTION
This submission addresses two main streams of work:

1. **Stream 1: The "Bulletproof" Foundation**:
    - Created a high-fidelity Kodi RPC mock harness using `mockito` 1.x.
    - Enhanced integration tests to verify the service's resilience against media server failures, including timeouts, connection errors, and malformed data.
    - Simulated timeouts using `with_chunked_body` and `std::thread::sleep` to bypass version-specific `mockito` limitations.

2. **Stream 3: "Clean House" & Core Stability**:
    - Fixed deterministic test expectations in `koditool`'s `test_select_random_episode_by_title`.
    - Resolved all Clippy warnings across the workspace, including redundant imports, needless lifetimes, and modernizing `map_or` to `is_ok_and`/`is_none_or`.
    - Improved application state initialization with idiomatic error creation and `Default` implementations.
    - Verified overall workspace health with `make test` and `make lint`.

---
*PR created automatically by Jules for task [7253161167304008269](https://jules.google.com/task/7253161167304008269) started by @DanceMore*