### PR TITLE
Implement TV Mode State Persistence

### DIFF
--- a/tv_mode_web/src/app_state.rs
+++ b/tv_mode_web/src/app_state.rs
@@ -171,6 +171,28 @@ pub struct AppState {
     pub show_mappings: Arc<RwLock<ShowMappings>>,
     pub tv_mode: Arc<RwLock<TVModeStatus>>,
     pub jukectl_channels: Arc<RwLock<Vec<JukectlChannel>>>,
+    pub config_dir: String,
+}
+
+impl AppState {
+    pub async fn save_to_disk(&self) {
+        let tv_mode = self.tv_mode.read().await;
+        let path = Path::new(&self.config_dir).join("persistent_state.json");
+
+        let json = match serde_json::to_string_pretty(&*tv_mode) {
+            Ok(json) => json,
+            Err(e) => {
+                error!("Failed to serialize TV mode state: {}", e);
+                return;
+            }
+        };
+
+        if let Err(e) = std::fs::write(&path, json) {
+            error!("Failed to save TV mode state to {:?}: {}", path, e);
+        } else {
+            debug!("Saved TV mode state to {:?}", path);
+        }
+    }
 }
 
 pub fn initialize() -> Result<AppState, std::io::Error> {
@@ -181,6 +203,7 @@ pub fn initialize() -> Result<AppState, std::io::Error> {
     let config_path = Path::new(&config_dir).join("config.yml");
     let mappings_path = Path::new(&config_dir).join("show_mappings.yml");
     let jukectl_path = Path::new(&config_dir).join("jukectl_channels.yml");
+    let persistent_path = Path::new(&config_dir).join("persistent_state.json");
 
     // Load config
     let config = match Config::load(config_path.to_str().unwrap()) {
@@ -224,12 +247,43 @@ pub fn initialize() -> Result<AppState, std::io::Error> {
         }
     };
 
+    // Load persistent state (optional)
+    let tv_mode = if persistent_path.exists() {
+        match std::fs::read_to_string(&persistent_path) {
+            Ok(content) => match serde_json::from_str::<TVModeStatus>(&content) {
+                Ok(mut state) => {
+                    info!("Loaded persistent TV mode state from {:?}", persistent_path);
+                    // Make sure to update the timer's remaining time
+                    state.sleep_timer.update_remaining_time();
+                    state
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to parse persistent state from {:?}: {}. Using default.",
+                        persistent_path, e
+                    );
+                    TVModeStatus::new()
+                }
+            },
+            Err(e) => {
+                warn!(
+                    "Failed to read persistent state from {:?}: {}. Using default.",
+                    persistent_path, e
+                );
+                TVModeStatus::new()
+            }
+        }
+    } else {
+        TVModeStatus::new()
+    };
+
     // Create app state with mutexes and Arc
     let app_state = AppState {
         rpc_client: Arc::new(RwLock::new(rpc_client)),
         show_mappings: Arc::new(RwLock::new(show_mappings)),
-        tv_mode: Arc::new(RwLock::new(TVModeStatus::new())),
+        tv_mode: Arc::new(RwLock::new(tv_mode)),
         jukectl_channels: Arc::new(RwLock::new(jukectl_channels)),
+        config_dir,
     };
 
     Ok(app_state)

--- a/tv_mode_web/src/routes/api.rs
+++ b/tv_mode_web/src/routes/api.rs
@@ -144,15 +144,25 @@ pub async fn play_random_show(
         ));
     }
 
-    let mut tv_mode = app_state.tv_mode.write().await;
-    tv_mode.active = true;
-    tv_mode.user = Some(user.to_string());
+    {
+        let mut tv_mode = app_state.tv_mode.write().await;
+        tv_mode.active = true;
+        tv_mode.user = Some(user.to_string());
+
+        if sleep_timer_hours == 0 {
+            // No sleep timer
+            tv_mode.sleep_timer.stop();
+        } else {
+            // With sleep timer
+            tv_mode.sleep_timer.start(sleep_timer_hours);
+        }
+    }
+
+    app_state.save_to_disk().await;
     
+    let tv_mode = app_state.tv_mode.read().await;
     if sleep_timer_hours == 0 {
-        // No sleep timer
-        tv_mode.sleep_timer.stop();
         info!("Enabling TV mode for user: {} with no sleep timer", user);
-        
         Ok(Json(StatusResponse::success(
             format!(
                 "Enabled TV mode for user '{}' with {} shows available (no sleep timer)",
@@ -162,10 +172,7 @@ pub async fn play_random_show(
             Some(tv_mode.clone()),
         )))
     } else {
-        // With sleep timer
-        tv_mode.sleep_timer.start(sleep_timer_hours);
         info!("Enabling TV mode for user: {} with {}h sleep timer", user, sleep_timer_hours);
-
         Ok(Json(StatusResponse::success(
             format!(
                 "Enabled TV mode for user '{}' with {} shows available ({}h sleep timer)",
@@ -213,11 +220,16 @@ pub async fn play_random_show_legacy(
 
     info!("Enabling TV mode for user: {} with no sleep timer (legacy endpoint)", user);
 
-    let mut tv_mode = app_state.tv_mode.write().await;
-    tv_mode.active = true;
-    tv_mode.user = Some(user.to_string());
-    // Don't start sleep timer for legacy endpoint
-    tv_mode.sleep_timer.stop();
+    {
+        let mut tv_mode = app_state.tv_mode.write().await;
+        tv_mode.active = true;
+        tv_mode.user = Some(user.to_string());
+        // Don't start sleep timer for legacy endpoint
+        tv_mode.sleep_timer.stop();
+    }
+
+    app_state.save_to_disk().await;
+    let tv_mode = app_state.tv_mode.read().await;
 
     Ok(Json(StatusResponse::success(
         format!(
@@ -246,20 +258,25 @@ pub async fn set_sleep_timer(
         ));
     }
 
-    let mut tv_mode = app_state.tv_mode.write().await;
-    
-    if !tv_mode.active {
-        return Err(Custom(
-            Status::BadRequest,
-            Json(StatusResponse::error(
-                "Cannot set sleep timer when TV mode is not active".to_string(),
-                Some(tv_mode.clone()),
-                None,
-            )),
-        ));
+    {
+        let mut tv_mode = app_state.tv_mode.write().await;
+
+        if !tv_mode.active {
+            return Err(Custom(
+                Status::BadRequest,
+                Json(StatusResponse::error(
+                    "Cannot set sleep timer when TV mode is not active".to_string(),
+                    Some(tv_mode.clone()),
+                    None,
+                )),
+            ));
+        }
+
+        tv_mode.sleep_timer.start(request.hours);
     }
 
-    tv_mode.sleep_timer.start(request.hours);
+    app_state.save_to_disk().await;
+    let tv_mode = app_state.tv_mode.read().await;
 
     info!("Sleep timer updated to {} hours", request.hours);
 
@@ -271,20 +288,25 @@ pub async fn set_sleep_timer(
 
 #[delete("/api/sleep-timer")]
 pub async fn disable_sleep_timer(app_state: &State<AppState>) -> ApiResponse<StatusResponse> {
-    let mut tv_mode = app_state.tv_mode.write().await;
-    
-    if !tv_mode.active {
-        return Err(Custom(
-            Status::BadRequest,
-            Json(StatusResponse::error(
-                "Cannot disable sleep timer when TV mode is not active".to_string(),
-                Some(tv_mode.clone()),
-                None,
-            )),
-        ));
+    {
+        let mut tv_mode = app_state.tv_mode.write().await;
+
+        if !tv_mode.active {
+            return Err(Custom(
+                Status::BadRequest,
+                Json(StatusResponse::error(
+                    "Cannot disable sleep timer when TV mode is not active".to_string(),
+                    Some(tv_mode.clone()),
+                    None,
+                )),
+            ));
+        }
+
+        tv_mode.sleep_timer.stop();
     }
 
-    tv_mode.sleep_timer.stop();
+    app_state.save_to_disk().await;
+    let tv_mode = app_state.tv_mode.read().await;
 
     info!("Sleep timer disabled");
 
@@ -296,14 +318,22 @@ pub async fn disable_sleep_timer(app_state: &State<AppState>) -> ApiResponse<Sta
 
 #[post("/api/stop")]
 pub async fn stop_tv_mode(app_state: &State<AppState>) -> ApiResponse<StatusResponse> {
-    let mut tv_mode = app_state.tv_mode.write().await;
+    let was_active;
+    let previous_user;
 
-    let was_active = tv_mode.active;
-    let previous_user = tv_mode.user.clone();
+    {
+        let mut tv_mode = app_state.tv_mode.write().await;
 
-    tv_mode.active = false;
-    tv_mode.user = None;
-    tv_mode.sleep_timer.stop();
+        was_active = tv_mode.active;
+        previous_user = tv_mode.user.clone();
+
+        tv_mode.active = false;
+        tv_mode.user = None;
+        tv_mode.sleep_timer.stop();
+    }
+
+    app_state.save_to_disk().await;
+    let tv_mode = app_state.tv_mode.read().await;
 
     let message = if was_active {
         match previous_user {

--- a/tv_mode_web/src/scheduler/mod.rs
+++ b/tv_mode_web/src/scheduler/mod.rs
@@ -136,11 +136,14 @@ async fn process_scheduler_iteration(app_state: &AppState) -> Result<bool, Strin
     if tv_mode_status.sleep_timer.is_expired() {
         info!("Sleep timer expired, disabling TV mode");
         
-        let mut tv_mode_write = app_state.tv_mode.write().await;
-        tv_mode_write.active = false;
-        tv_mode_write.user = None;
-        tv_mode_write.sleep_timer.stop();
-        drop(tv_mode_write); // Release the write lock early
+        {
+            let mut tv_mode_write = app_state.tv_mode.write().await;
+            tv_mode_write.active = false;
+            tv_mode_write.user = None;
+            tv_mode_write.sleep_timer.stop();
+        }
+
+        app_state.save_to_disk().await;
         
         // Note: We just disable TV mode here. The media server will handle 
         // stopping playback naturally, or you can add a stop call here if 

--- a/tv_mode_web/tests/state_persistence.rs
+++ b/tv_mode_web/tests/state_persistence.rs
@@ -1,0 +1,97 @@
+mod harness;
+
+use rocket::local::asynchronous::Client;
+use rocket::http::Status;
+use std::fs;
+use std::env;
+use tempfile::tempdir;
+
+async fn setup_config_dir(config_dir: &std::path::Path) {
+    let config_yml = "url: http://localhost:8080\nusername: user\npassword: pass\n";
+    let show_mappings_yml = "user1:\n  - Show 1\n";
+
+    fs::write(config_dir.join("config.yml"), config_yml).unwrap();
+    fs::write(config_dir.join("show_mappings.yml"), show_mappings_yml).unwrap();
+    // jukectl_channels.yml is optional
+}
+
+fn set_config_dir(path: &std::path::Path) {
+    env::set_var("CONFIG_DIR", path.to_str().unwrap());
+}
+
+#[rocket::async_test]
+async fn test_state_persistence_across_restarts() {
+    let tmp_dir = tempdir().expect("Failed to create temp dir");
+    let config_dir = tmp_dir.path();
+    setup_config_dir(config_dir).await;
+    set_config_dir(config_dir);
+
+    // 1. Start first server instance and enable TV mode
+    {
+        let rocket = tv_mode_web::build_rocket();
+        let client = Client::tracked(rocket).await.expect("valid rocket instance");
+
+        let response = client.post("/api/play/user1").dispatch().await;
+        assert_eq!(response.status(), Status::Ok);
+
+        // Give it a moment to ensure file is written if it's async (though we await it)
+        rocket::tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let body: serde_json::Value = response.into_json().await.unwrap();
+        assert_eq!(body["status"], "success");
+        assert_eq!(body["tv_mode"]["active"], true);
+        assert_eq!(body["tv_mode"]["user"], "user1");
+
+        // Verify persistent_state.json exists
+        assert!(config_dir.join("persistent_state.json").exists());
+    }
+
+    // 2. Start second server instance and verify state is restored
+    {
+        let rocket = tv_mode_web::build_rocket();
+        let client = Client::tracked(rocket).await.expect("valid rocket instance");
+
+        let response = client.get("/api/status").dispatch().await;
+        assert_eq!(response.status(), Status::Ok);
+
+        let body: serde_json::Value = response.into_json().await.unwrap();
+        // Even if Kodi is unreachable, tv_mode state should be restored
+        assert_eq!(body["tv_mode"]["active"], true, "TV mode should be active after restart. Body: {:?}", body);
+        assert_eq!(body["tv_mode"]["user"], "user1");
+    }
+}
+
+#[rocket::async_test]
+async fn test_state_persistence_stop_tv_mode() {
+    let tmp_dir = tempdir().expect("Failed to create temp dir");
+    let config_dir = tmp_dir.path();
+    setup_config_dir(config_dir).await;
+    set_config_dir(config_dir);
+
+    // 1. Enable TV mode
+    {
+        let rocket = tv_mode_web::build_rocket();
+        let client = Client::tracked(rocket).await.expect("valid rocket instance");
+        client.post("/api/play/user1").dispatch().await;
+    }
+
+    // 2. Stop TV mode in a new instance
+    {
+        let rocket = tv_mode_web::build_rocket();
+        let client = Client::tracked(rocket).await.expect("valid rocket instance");
+
+        let response = client.post("/api/stop").dispatch().await;
+        assert_eq!(response.status(), Status::Ok);
+    }
+
+    // 3. Verify it stays stopped in a third instance
+    {
+        let rocket = tv_mode_web::build_rocket();
+        let client = Client::tracked(rocket).await.expect("valid rocket instance");
+
+        let response = client.get("/api/status").dispatch().await;
+        let body: serde_json::Value = response.into_json().await.unwrap();
+        assert_eq!(body["tv_mode"]["active"], false);
+        assert_eq!(body["tv_mode"]["user"], serde_json::Value::Null);
+    }
+}

--- a/tv_mode_web/tests/web_integrity.rs
+++ b/tv_mode_web/tests/web_integrity.rs
@@ -109,7 +109,7 @@ async fn create_test_client(kodi_url: Option<&str>) -> Client {
 
 #[rocket::async_test]
 async fn test_api_users() {
-    let client = create_test_client().await;
+    let client = create_test_client(None).await;
     let response = client.get("/api/users").dispatch().await;
     assert_eq!(response.status(), Status::Ok);
     let body = response.into_string().await.unwrap();
@@ -119,7 +119,7 @@ async fn test_api_users() {
 
 #[rocket::async_test]
 async fn test_api_play_and_status() {
-    let client = create_test_client().await;
+    let client = create_test_client(None).await;
 
     // Initially inactive
     let response = client.get("/api/status").dispatch().await;
@@ -145,7 +145,7 @@ async fn test_api_play_and_status() {
 
 #[rocket::async_test]
 async fn test_api_play_invalid_user() {
-    let client = create_test_client().await;
+    let client = create_test_client(None).await;
     let response = client.post("/api/play/nonexistent").dispatch().await;
     assert_eq!(response.status(), Status::BadRequest);
     let body = response.into_string().await.unwrap();


### PR DESCRIPTION
This change implements TV Mode state persistence for `tv_mode_web`, ensuring that active user settings and sleep timer timestamps survive a service restart.

Key changes:
- `tv_mode_web/src/app_state.rs`: Added `AppState::save_to_disk()` and logic to load `persistent_state.json` in `initialize()`.
- `tv_mode_web/src/routes/api.rs`: Updated routes to trigger state saving after modification.
- `tv_mode_web/src/scheduler/mod.rs`: Updated scheduler to save state when the sleep timer expires.
- `tv_mode_web/tests/state_persistence.rs`: Added new integration tests for persistence.
- `tv_mode_web/tests/web_integrity.rs`: Fixed compilation of existing tests.

Verification:
- Ran `cargo test -p tv_mode_web -- --test-threads=1`. All 11 tests passed.
- Manually verified that `persistent_state.json` is created in the config directory.

---
*PR created automatically by Jules for task [11097892914579265040](https://jules.google.com/task/11097892914579265040) started by @DanceMore*